### PR TITLE
Android pass through custom user profile variable to smartwhere

### DIFF
--- a/sdk-android/TuneMarketingConsoleSDK/src/androidTest/java/com/tune/smartwhere/SmartWhereTuneSingletonIntegrationTests.java
+++ b/sdk-android/TuneMarketingConsoleSDK/src/androidTest/java/com/tune/smartwhere/SmartWhereTuneSingletonIntegrationTests.java
@@ -1,0 +1,297 @@
+package com.tune.smartwhere;
+
+import android.content.Context;
+
+import com.tune.Tune;
+import com.tune.TuneTestWrapper;
+import com.tune.TuneUnitTest;
+import com.tune.ma.analytics.model.TuneAnalyticsVariable;
+
+import org.mockito.ArgumentMatcher;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class SmartWhereTuneSingletonIntegrationTests extends TuneUnitTest {
+    private TuneSmartWhere mockTuneSmartwhere;
+    private TuneSmartwhereConfiguration mockTuneSmartwhereConfiguration;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        shutdownWaitAndRecreatePubQueue();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        TuneSmartWhere.instance = null;
+        super.tearDown();
+    }
+
+    public void testregisterCustomProfileStringWithDefaultCallsSmartWhereSetAttributeValueWhenAvailable() throws Exception {
+        setMocksToEnableSmartWhere();
+
+        String expectedName = "testStringName";
+        String expectedValue = "defaultString";
+        TuneAnalyticsVariable expectedAnalyticsVariable = new TuneAnalyticsVariable(expectedName, expectedValue);
+
+        TuneTestWrapper.getInstance().registerCustomProfileString(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere).setAttributeValueFromAnalyticsVariable(eq(mContext), argThat(new TuneAnalyticsVariableMatcher<TuneAnalyticsVariable>(expectedAnalyticsVariable)));
+    }
+
+    public void testegisterCustomProfileStringWithDefaultDoesntCallsSmartWhereWhenNotAvailable() throws Exception {
+        setMocksToDisableSmartWhere();
+
+        String expectedName = "Name";
+        String expectedValue = "defaultString";
+
+        TuneTestWrapper.getInstance().registerCustomProfileString(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere, never()).setAttributeValueFromAnalyticsVariable(any(Context.class), any(TuneAnalyticsVariable.class));
+    }
+
+    public void testregisterCustomProfileNumberIntWithDefaultCallsSmartWhereSetAttributeValueWhenAvailable() throws Exception {
+        setMocksToEnableSmartWhere();
+
+        String expectedName = "number name";
+        int expectedValue = 10;
+        TuneAnalyticsVariable expectedAnalyticsVariable = new TuneAnalyticsVariable(expectedName, expectedValue);
+
+        TuneTestWrapper.getInstance().registerCustomProfileNumber(expectedName, 10);
+
+        verify(mockTuneSmartwhere).setAttributeValueFromAnalyticsVariable(eq(mContext), argThat(new TuneAnalyticsVariableMatcher<TuneAnalyticsVariable>(expectedAnalyticsVariable)));
+    }
+
+    public void testregisterCustomProfileNumberIntWithDefaultDoesntCallsSmartWhereSetAttributeValueWhenNotAvailable() throws Exception {
+        setMocksToDisableSmartWhere();
+
+        String expectedName = "another number";
+
+        TuneTestWrapper.getInstance().registerCustomProfileNumber(expectedName, 10);
+
+        verify(mockTuneSmartwhere, never()).setAttributeValueFromAnalyticsVariable(any(Context.class), any(TuneAnalyticsVariable.class));
+    }
+
+    public void testregisterCustomProfileNumberDoubleWithDefaultCallsSmartWhereSetAttributeValueWhenAvailable() throws Exception {
+        setMocksToEnableSmartWhere();
+
+        String expectedName = "double";
+        double expectedValue = 10.2;
+        TuneAnalyticsVariable expectedAnalyticsVariable = new TuneAnalyticsVariable(expectedName, expectedValue);
+
+        TuneTestWrapper.getInstance().registerCustomProfileNumber(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere).setAttributeValueFromAnalyticsVariable(eq(mContext), argThat(new TuneAnalyticsVariableMatcher<TuneAnalyticsVariable>(expectedAnalyticsVariable)));
+    }
+
+    public void testregisterCustomProfileNumberDoubleWithDefaultDoesntCallsSmartWhereSetAttributeValueWhenNotAvailable() throws Exception {
+        setMocksToDisableSmartWhere();
+
+        String expectedName = "no double";
+
+        TuneTestWrapper.getInstance().registerCustomProfileNumber(expectedName, 10.4);
+
+        verify(mockTuneSmartwhere, never()).setAttributeValueFromAnalyticsVariable(any(Context.class), any(TuneAnalyticsVariable.class));
+    }
+
+    public void testregisterCustomProfileNumberFloatWithDefaultCallsSmartWhereSetAttributeValueWhenAvailable() throws Exception {
+        setMocksToEnableSmartWhere();
+
+        String expectedName = "registerFloat";
+        float expectedValue = 99.9f;
+        TuneAnalyticsVariable expectedAnalyticsVariable = new TuneAnalyticsVariable(expectedName, expectedValue);
+
+        TuneTestWrapper.getInstance().registerCustomProfileNumber(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere).setAttributeValueFromAnalyticsVariable(eq(mContext), argThat(new TuneAnalyticsVariableMatcher<TuneAnalyticsVariable>(expectedAnalyticsVariable)));
+    }
+
+    public void testregisterCustomProfileNumberfloatWithDefaultDoesntCallsSmartWhereSetAttributeValueWhenNotAvailable() throws Exception {
+        setMocksToDisableSmartWhere();
+
+        String expectedName = "shouldntbeafloat";
+
+        TuneTestWrapper.getInstance().registerCustomProfileNumber(expectedName, 10.43f);
+
+        verify(mockTuneSmartwhere, never()).setAttributeValueFromAnalyticsVariable(any(Context.class), any(TuneAnalyticsVariable.class));
+    }
+
+    public void testsetCustomProfileStringValueCallsSmartWhereSetAttributeValueWhenAvailable() throws Exception {
+        setMocksToEnableSmartWhere();
+
+        String expectedName = "setString";
+        String expectedValue = "stringvalue";
+        TuneAnalyticsVariable expectedAnalyticsVariable = new TuneAnalyticsVariable(expectedName, expectedValue);
+
+        TuneTestWrapper.getInstance().setCustomProfileStringValue(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere).setAttributeValueFromAnalyticsVariable(eq(mContext), argThat(new TuneAnalyticsVariableMatcher<TuneAnalyticsVariable>(expectedAnalyticsVariable)));
+    }
+
+    public void testsetCustomProfileStringValueDoesntCallSmartWhereSetAttributeValueWhenNotAvailable() throws Exception {
+        setMocksToDisableSmartWhere();
+
+        String expectedName = "dontsetstring";
+        String expectedValue = "stringvalue";
+
+        TuneTestWrapper.getInstance().setCustomProfileStringValue(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere, never()).setAttributeValueFromAnalyticsVariable(any(Context.class), any(TuneAnalyticsVariable.class));
+    }
+
+    public void testsetCustomProfileNumberIntCallsSmartWhereSetAttributeValueWhenAvailable() throws Exception {
+        setMocksToEnableSmartWhere();
+
+        String expectedName = "setIntNmme";
+        int expectedValue = 23;
+        TuneAnalyticsVariable expectedAnalyticsVariable = new TuneAnalyticsVariable(expectedName, expectedValue);
+
+        TuneTestWrapper.getInstance().setCustomProfileNumber(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere).setAttributeValueFromAnalyticsVariable(eq(mContext), argThat(new TuneAnalyticsVariableMatcher<TuneAnalyticsVariable>(expectedAnalyticsVariable)));
+    }
+
+    public void testsetCustomProfileNumberIntDoesntCallSmartWhereSetAttributeValueWhenNotAvailable() throws Exception {
+        setMocksToDisableSmartWhere();
+
+        String expectedName = "noInt";
+        int expectedValue = 333;
+
+        TuneTestWrapper.getInstance().setCustomProfileNumber(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere, never()).setAttributeValueFromAnalyticsVariable(any(Context.class), any(TuneAnalyticsVariable.class));
+    }
+
+    public void testsetCustomProfileNumberDoubleCallsSmartWhereSetAttributeValueWhenAvailable() throws Exception {
+        setMocksToEnableSmartWhere();
+
+        String expectedName = "setDoubleName";
+        double expectedValue = 23.888;
+        TuneAnalyticsVariable expectedAnalyticsVariable = new TuneAnalyticsVariable(expectedName, expectedValue);
+
+        TuneTestWrapper.getInstance().setCustomProfileNumber(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere).setAttributeValueFromAnalyticsVariable(eq(mContext), argThat(new TuneAnalyticsVariableMatcher<TuneAnalyticsVariable>(expectedAnalyticsVariable)));
+    }
+
+    public void testsetCustomProfileNumberDoubleDoesntCallSmartWhereSetAttributeValueWhenNotAvailable() throws Exception {
+        setMocksToDisableSmartWhere();
+
+        String expectedName = "dontSetDoubleName";
+        double expectedValue = 333;
+
+        TuneTestWrapper.getInstance().setCustomProfileNumber(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere, never()).setAttributeValueFromAnalyticsVariable(any(Context.class), any(TuneAnalyticsVariable.class));
+    }
+
+    public void testsetCustomProfileNumberFloatCallsSmartWhereSetAttributeValueWhenAvailable() throws Exception {
+        setMocksToEnableSmartWhere();
+
+        String expectedName = "setFloatName";
+        float expectedValue = 44.4f;
+        TuneAnalyticsVariable expectedAnalyticsVariable = new TuneAnalyticsVariable(expectedName, expectedValue);
+
+        TuneTestWrapper.getInstance().setCustomProfileNumber(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere).setAttributeValueFromAnalyticsVariable(eq(mContext), argThat(new TuneAnalyticsVariableMatcher<TuneAnalyticsVariable>(expectedAnalyticsVariable)));
+    }
+
+    public void testsetCustomProfileNumberFloatDoesntCallSmartWhereSetAttributeValueWhenNotAvailable() throws Exception {
+        setMocksToDisableSmartWhere();
+
+        String expectedName = "dontSetFloatName";
+        float expectedValue = 323.33f;
+
+        TuneTestWrapper.getInstance().setCustomProfileNumber(expectedName, expectedValue);
+
+        verify(mockTuneSmartwhere, never()).setAttributeValueFromAnalyticsVariable(any(Context.class), any(TuneAnalyticsVariable.class));
+    }
+
+    public void testclearCustomProfileVariableCallsOnSmartWhereWhenAvailable() throws Exception {
+        setMocksToEnableSmartWhere();
+
+        String expectedName = "clear name";
+
+        TuneTestWrapper.getInstance().clearCustomProfileVariable(expectedName);
+        verify(mockTuneSmartwhere).clearAttributeValue(mContext, expectedName);
+    }
+
+    public void testclearCustomProfileVariableDoesntCallOnSmartWhereWhenNotAvailable() throws Exception {
+        setMocksToDisableSmartWhere();
+
+        String expectedName = "clear name";
+
+        TuneTestWrapper.getInstance().clearCustomProfileVariable(expectedName);
+        verify(mockTuneSmartwhere, never()).clearAttributeValue(any(Context.class), anyString());
+    }
+
+    //  Helper methods
+    private void setMocksToEnableSmartWhere() {
+        mockTuneSmartwhere = mock(TuneSmartWhere.class);
+        mockTuneSmartwhereConfiguration = mock(TuneSmartwhereConfiguration.class);
+        TuneSmartWhere.instance = mockTuneSmartwhere;
+        doReturn(mockTuneSmartwhereConfiguration).when(mockTuneSmartwhere).getConfiguration();
+        doReturn(true).when(mockTuneSmartwhereConfiguration).isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS);
+    }
+
+    private void setMocksToDisableSmartWhere() {
+        mockTuneSmartwhere = mock(TuneSmartWhere.class);
+        mockTuneSmartwhereConfiguration = mock(TuneSmartwhereConfiguration.class);
+        TuneSmartWhere.instance = mockTuneSmartwhere;
+        doReturn(mockTuneSmartwhereConfiguration).when(mockTuneSmartwhere).getConfiguration();
+        doReturn(false).when(mockTuneSmartwhereConfiguration).isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS);
+    }
+
+    private class TuneAnalyticsVariableMatcher<T> extends ArgumentMatcher<T> {
+        TuneAnalyticsVariable thisObject;
+
+        TuneAnalyticsVariableMatcher(TuneAnalyticsVariable thisObject) {
+            this.thisObject = thisObject;
+        }
+
+        @Override
+        public boolean matches(Object argument) {
+            return argument instanceof TuneAnalyticsVariable &&
+                    thisObject.getName().equals(((TuneAnalyticsVariable) argument).getName()) &&
+                    thisObject.getType().equals(((TuneAnalyticsVariable) argument).getType()) &&
+                    thisObject.getValue().equals(((TuneAnalyticsVariable) argument).getValue()) &&
+                    thisObject.getHashType().equals(((TuneAnalyticsVariable) argument).getHashType());
+        }
+    }
+
+    private void shutdownWaitAndRecreatePubQueue() throws InterruptedException {
+        tune.getPubQueue().shutdown();
+        tune.getPubQueue().awaitTermination(60, TimeUnit.SECONDS);
+        Field declaredField =  null;
+        try {
+            declaredField = Tune.class.getDeclaredField("pubQueue");
+            boolean accessible = declaredField.isAccessible();
+
+            declaredField.setAccessible(true);
+
+            Executor exec = Executors.newSingleThreadExecutor();
+            declaredField.set(tune, exec);
+
+            declaredField.setAccessible(accessible);
+
+        } catch (NoSuchFieldException
+                | SecurityException
+                | IllegalArgumentException
+                | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/sdk-android/TuneMarketingConsoleSDK/src/androidTest/java/com/tune/smartwhere/TuneSmartWhereFakeAttribute.java
+++ b/sdk-android/TuneMarketingConsoleSDK/src/androidTest/java/com/tune/smartwhere/TuneSmartWhereFakeAttribute.java
@@ -1,0 +1,30 @@
+package com.tune.smartwhere;
+
+import android.content.Context;
+
+import java.util.HashMap;
+
+@SuppressWarnings("WeakerAccess")
+public class  TuneSmartWhereFakeAttribute{
+    static TuneSmartWhereFakeAttribute instance;
+
+
+    public static Object getInstance(Context context) {
+        return instance;
+    }
+
+    @SuppressWarnings("unused")
+    public void setAttributeValue(String name, String value) {
+    }
+
+    @SuppressWarnings("unused")
+    public void removeAttributeValue(String name) {
+    }
+
+    @SuppressWarnings("unused")
+    public HashMap<String, String> getAttributes() {
+        return null;
+    }
+}
+
+

--- a/sdk-android/TuneMarketingConsoleSDK/src/androidTest/java/com/tune/smartwhere/TuneSmartWhereFakeTrackingAttribute.java
+++ b/sdk-android/TuneMarketingConsoleSDK/src/androidTest/java/com/tune/smartwhere/TuneSmartWhereFakeTrackingAttribute.java
@@ -2,28 +2,17 @@ package com.tune.smartwhere;
 
 import android.content.Context;
 
-import java.util.HashMap;
-
 @SuppressWarnings("WeakerAccess")
-public class  TuneSmartWhereFakeAttribute{
-    static TuneSmartWhereFakeAttribute instance;
+public class TuneSmartWhereFakeTrackingAttribute {
+    static TuneSmartWhereFakeTrackingAttribute instance;
 
     public static Object getInstance(Context context) {
         return instance;
     }
 
-    @SuppressWarnings("unused")
     public void setAttributeValue(String name, String value) {
     }
 
-    @SuppressWarnings("unused")
     public void removeAttributeValue(String name) {
     }
-
-    @SuppressWarnings("unused")
-    public HashMap<String, String> getAttributes() {
-        return null;
-    }
 }
-
-

--- a/sdk-android/TuneMarketingConsoleSDK/src/androidTest/java/com/tune/smartwhere/TuneSmartWhereTests.java
+++ b/sdk-android/TuneMarketingConsoleSDK/src/androidTest/java/com/tune/smartwhere/TuneSmartWhereTests.java
@@ -3,6 +3,8 @@ package com.tune.smartwhere;
 import android.annotation.SuppressLint;
 import android.content.Context;
 
+import com.tune.BuildConfig;
+import com.tune.Tune;
 import com.tune.TuneEvent;
 import com.tune.TuneUnitTest;
 import com.tune.ma.analytics.model.TuneAnalyticsVariable;
@@ -149,6 +151,21 @@ public class TuneSmartWhereTests extends TuneUnitTest {
         testObj.startMonitoring(context, addId, conversionKey, false);
 
         assertTrue(FakeProximityControl.hasStartServiceBeenCalled);
+    }
+
+    public void testStartMonitoringAddsTrackingMetadata() throws Exception {
+        String addId = "addId";
+        String conversionKey = "conversionKey";
+
+        testObj.startMonitoring(context, addId, conversionKey, false);
+
+        verify(mockTrackingAttribute).setAttributeValue(
+                TuneSmartWhere.TUNE_SMARTWHERE_ANALYTICS_VARIABLE_ATTRIBUTE_PREFIX + TuneSmartWhere.TUNE_SDK_VERSION_TRACKING_KEY ,
+                BuildConfig.VERSION_NAME);
+        verify(mockTrackingAttribute).setAttributeValue(
+                TuneSmartWhere.TUNE_SMARTWHERE_ANALYTICS_VARIABLE_ATTRIBUTE_PREFIX + TuneSmartWhere.TUNE_MAT_ID_TRACKING_KEY ,
+                Tune.getInstance().getMatId());
+
     }
 
     public void testSetPackageNameCallsConfigureServiceWithPackageName() throws Exception {

--- a/sdk-android/TuneMarketingConsoleSDK/src/main/java/com/tune/Tune.java
+++ b/sdk-android/TuneMarketingConsoleSDK/src/main/java/com/tune/Tune.java
@@ -462,6 +462,7 @@ public class Tune {
 
         if (TuneSmartWhere.getInstance().getConfiguration().isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS)) {
             TuneSmartWhere.getInstance().processMappedEvent(mContext, eventData);
+            TuneSmartWhere.getInstance().setAttributeValuesFromEventTags(mContext, eventData);
         }
 
         return;
@@ -2667,8 +2668,12 @@ public class Tune {
         if (TuneManager.getProfileForUser("registerCustomProfileString") == null) {
             return;
         }
+        TuneAnalyticsVariable analyticsVariable = new TuneAnalyticsVariable(variableName, defaultValue);
+        TuneManager.getInstance().getProfileManager().registerCustomProfileVariable(analyticsVariable);
 
-        TuneManager.getInstance().getProfileManager().registerCustomProfileVariable(new TuneAnalyticsVariable(variableName, defaultValue));
+        if (TuneSmartWhere.getInstance().getConfiguration().isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS)) {
+            TuneSmartWhere.getInstance().setAttributeValueFromAnalyticsVariable(mContext, analyticsVariable);
+        }
     }
 
     /**
@@ -2711,7 +2716,12 @@ public class Tune {
             return;
         }
 
-        TuneManager.getInstance().getProfileManager().registerCustomProfileVariable(new TuneAnalyticsVariable(variableName, defaultValue));
+        TuneAnalyticsVariable analyticsVariable = new TuneAnalyticsVariable(variableName, defaultValue);
+        TuneManager.getInstance().getProfileManager().registerCustomProfileVariable(analyticsVariable);
+
+        if (TuneSmartWhere.getInstance().getConfiguration().isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS)) {
+            TuneSmartWhere.getInstance().setAttributeValueFromAnalyticsVariable(mContext, analyticsVariable);
+        }
     }
 
     /**
@@ -2733,7 +2743,12 @@ public class Tune {
             return;
         }
 
-        TuneManager.getInstance().getProfileManager().registerCustomProfileVariable(new TuneAnalyticsVariable(variableName, defaultValue));
+        TuneAnalyticsVariable analyticsVariable = new TuneAnalyticsVariable(variableName, defaultValue);
+        TuneManager.getInstance().getProfileManager().registerCustomProfileVariable(analyticsVariable);
+
+        if (TuneSmartWhere.getInstance().getConfiguration().isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS)) {
+            TuneSmartWhere.getInstance().setAttributeValueFromAnalyticsVariable(mContext, analyticsVariable);
+        }
     }
 
     /**
@@ -2755,7 +2770,12 @@ public class Tune {
             return;
         }
 
-        TuneManager.getInstance().getProfileManager().registerCustomProfileVariable(new TuneAnalyticsVariable(variableName, defaultValue));
+        TuneAnalyticsVariable analyticsVariable = new TuneAnalyticsVariable(variableName, defaultValue);
+        TuneManager.getInstance().getProfileManager().registerCustomProfileVariable(analyticsVariable);
+
+        if (TuneSmartWhere.getInstance().getConfiguration().isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS)) {
+            TuneSmartWhere.getInstance().setAttributeValueFromAnalyticsVariable(mContext, analyticsVariable);
+        }
     }
 
     /**
@@ -2797,7 +2817,12 @@ public class Tune {
             return;
         }
 
-        TuneManager.getInstance().getProfileManager().setCustomProfileVariable(new TuneAnalyticsVariable(variableName, value));
+        TuneAnalyticsVariable analyticsVariable = new TuneAnalyticsVariable(variableName, value);
+        TuneManager.getInstance().getProfileManager().setCustomProfileVariable(analyticsVariable);
+
+        if (TuneSmartWhere.getInstance().getConfiguration().isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS)) {
+            TuneSmartWhere.getInstance().setAttributeValueFromAnalyticsVariable(mContext, analyticsVariable);
+        }
     }
 
     /**
@@ -2835,7 +2860,12 @@ public class Tune {
             return;
         }
 
-        TuneManager.getInstance().getProfileManager().setCustomProfileVariable(new TuneAnalyticsVariable(variableName, value));
+        TuneAnalyticsVariable analyticsVariable = new TuneAnalyticsVariable(variableName, value);
+        TuneManager.getInstance().getProfileManager().setCustomProfileVariable(analyticsVariable);
+
+        if (TuneSmartWhere.getInstance().getConfiguration().isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS)) {
+            TuneSmartWhere.getInstance().setAttributeValueFromAnalyticsVariable(mContext, analyticsVariable);
+        }
     }
 
     /**
@@ -2854,7 +2884,12 @@ public class Tune {
             return;
         }
 
-        TuneManager.getInstance().getProfileManager().setCustomProfileVariable(new TuneAnalyticsVariable(variableName, value));
+        TuneAnalyticsVariable analyticsVariable = new TuneAnalyticsVariable(variableName, value);
+        TuneManager.getInstance().getProfileManager().setCustomProfileVariable(analyticsVariable);
+
+        if (TuneSmartWhere.getInstance().getConfiguration().isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS)) {
+            TuneSmartWhere.getInstance().setAttributeValueFromAnalyticsVariable(mContext, analyticsVariable);
+        }
     }
 
     /**
@@ -2873,7 +2908,12 @@ public class Tune {
             return;
         }
 
-        TuneManager.getInstance().getProfileManager().setCustomProfileVariable(new TuneAnalyticsVariable(variableName, value));
+        TuneAnalyticsVariable analyticsVariable = new TuneAnalyticsVariable(variableName, value);
+        TuneManager.getInstance().getProfileManager().setCustomProfileVariable(analyticsVariable);
+
+        if (TuneSmartWhere.getInstance().getConfiguration().isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS)) {
+            TuneSmartWhere.getInstance().setAttributeValueFromAnalyticsVariable(mContext, analyticsVariable);
+        }
     }
 
     /**
@@ -3019,6 +3059,10 @@ public class Tune {
         }
 
         TuneManager.getInstance().getProfileManager().clearCertainCustomProfileVariable(variableName);
+
+        if (TuneSmartWhere.getInstance().getConfiguration().isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS)) {
+            TuneSmartWhere.getInstance().clearAttributeValue(mContext, variableName);
+        }
     }
 
     /**
@@ -3036,6 +3080,10 @@ public class Tune {
         }
 
         TuneManager.getInstance().getProfileManager().clearAllCustomProfileVariables();
+
+        if (TuneSmartWhere.getInstance().getConfiguration().isPermissionGranted(TuneSmartwhereConfiguration.GRANT_SMARTWHERE_TUNE_EVENTS)) {
+            TuneSmartWhere.getInstance().clearAllAttributeValues(mContext);
+        }
     }
 
     /**

--- a/sdk-android/TuneMarketingConsoleSDK/src/main/java/com/tune/smartwhere/TuneSmartWhere.java
+++ b/sdk-android/TuneMarketingConsoleSDK/src/main/java/com/tune/smartwhere/TuneSmartWhere.java
@@ -28,7 +28,8 @@ public class TuneSmartWhere {
     protected static volatile TuneSmartWhere instance = null;
 
     static final String TUNE_SMARTWHERE_ANALYTICS_VARIABLE_ATTRIBUTE_PREFIX = "T_A_V_";
-    private static final String TUNE_SDK_VERSION_TRACKING_KEY = "TUNE_SDK_VERSION";
+    static final String TUNE_SDK_VERSION_TRACKING_KEY = "TUNE_SDK_VERSION";
+    static final String TUNE_MAT_ID_TRACKING_KEY = "TUNE_MAT_ID";
 
     static final String TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_PROXIMITYCONTROL = "com.proximity.library.ProximityControl";
     static final String TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_ATTRIBUTE = "com.proximity.library.Attribute";
@@ -138,6 +139,7 @@ public class TuneSmartWhere {
         if (targetClass != null) {
 
             setTrackingAttributeValue(context, TUNE_SDK_VERSION_TRACKING_KEY, BuildConfig.VERSION_NAME);
+            setTrackingAttributeValue(context, TUNE_MAT_ID_TRACKING_KEY, Tune.getInstance().getMatId());
 
             HashMap<String, String> config = new HashMap<>();
 

--- a/sdk-android/TuneMarketingConsoleSDK/src/main/java/com/tune/smartwhere/TuneSmartWhere.java
+++ b/sdk-android/TuneMarketingConsoleSDK/src/main/java/com/tune/smartwhere/TuneSmartWhere.java
@@ -5,8 +5,10 @@ import android.content.Context;
 import com.tune.Tune;
 import com.tune.TuneEvent;
 import com.tune.TuneUtils;
+import com.tune.ma.analytics.model.TuneAnalyticsVariable;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import static com.tune.TuneConstants.STRING_FALSE;
@@ -22,9 +24,12 @@ import static com.tune.TuneEvent.NAME_SESSION;
  */
 
 public class TuneSmartWhere {
-    private static volatile TuneSmartWhere instance = null;
+    protected static volatile TuneSmartWhere instance = null;
 
-    private static final String TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_PROXIMITYCONTROL = "com.proximity.library.ProximityControl";
+    static final String TUNE_SMARTWHERE_ANALYTICS_VARIABLE_ATTRIBUTE_PREFIX = "TUNE_ANALYTICS_VARIABLE_";
+
+    static final String TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_PROXIMITYCONTROL = "com.proximity.library.ProximityControl";
+    static final String TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_ATTRIBUTE = "com.proximity.library.Attribute";
     private static final String TUNE_SMARTWHERE_NOTIFICATION_SERVICE = "com.tune.smartwhere.TuneSmartWhereNotificationService";
 
     private static final String TUNE_SMARTWHERE_API_KEY = "API_KEY";
@@ -41,6 +46,10 @@ public class TuneSmartWhere {
     private static final String TUNE_SMARTWHERE_METHOD_START_SERVICE = "startService";
     private static final String TUNE_SMARTWHERE_METHOD_STOP_SERVICE = "stopService";
     private static final String TUNE_SMARTWHERE_METHOD_PROCESS_MAPPED_EVENT = "processMappedEvent";
+    private static final String TUNE_SMARTWHERE_ATTRIBUTE_METHOD_SET_ATTRIBUTE_VALUE = "setAttributeValue";
+    private static final String TUNE_SMARTWHERE_ATTRIBUTE_METHOD_REMOVE_ATTRIBUTE_VALUE = "removeAttributeValue";
+    private static final String TUNE_SMARTWHERE_ATTRIBUTE_METHOD_GET_ATTRIBUTE_MAP = "getAttributes";
+    private static final String TUNE_SMARTWHERE_ATTRIBUTE_METHOD_GET_INSTANCE = "getInstance";
 
     private TuneSmartwhereConfiguration mConfiguration;
 
@@ -92,7 +101,6 @@ public class TuneSmartWhere {
      * @return True if Smartwhere is enabled.
      */
     public boolean isEnabled() {
-        boolean test = (mConfiguration != null);
         return (mConfiguration != null);
     }
 
@@ -101,7 +109,7 @@ public class TuneSmartWhere {
      * @return the current {@link TuneSmartwhereConfiguration}.
      * To make changes to the Smartwhere options, use {@link TuneSmartWhere#configure(TuneSmartwhereConfiguration)}
      */
-    public final TuneSmartwhereConfiguration getConfiguration() {
+    public TuneSmartwhereConfiguration getConfiguration() {
         return (mConfiguration == null ? new TuneSmartwhereConfiguration() : mConfiguration);
     }
 
@@ -122,7 +130,7 @@ public class TuneSmartWhere {
      * @param tuneConversionKey TUNE Conversion Key
      * @param debugMode Debug Mode
      */
-    public void startMonitoring(Context context, String tuneAdvertiserId, String tuneConversionKey, boolean debugMode) {
+    void startMonitoring(Context context, String tuneAdvertiserId, String tuneConversionKey, boolean debugMode) {
         Class targetClass = classForName(TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_PROXIMITYCONTROL);
         if (targetClass != null) {
             HashMap<String, String> config = new HashMap<>();
@@ -157,7 +165,7 @@ public class TuneSmartWhere {
      * Stops SmartWhere proximity monitoring.
      * @param context Application Context
      */
-    public void stopMonitoring(Context context) {
+    void stopMonitoring(Context context) {
         Class targetClass = classForName(TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_PROXIMITYCONTROL);
         if (targetClass != null) {
             HashMap<String, String> config = new HashMap<>();
@@ -241,11 +249,108 @@ public class TuneSmartWhere {
         }
     }
 
+    /**
+     * Add user attributes that are used for conditions and notification replacements from TuneAnalyticsVariable.
+     * @param context Application Context
+     * @param analyticsVariable TuneAnalyticsVariable
+     */
+    public void setAttributeValueFromAnalyticsVariable(Context context, TuneAnalyticsVariable analyticsVariable) {
+        Class<?> targetClass = classForName(TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_ATTRIBUTE);
+        if (targetClass == null) return;
+
+        try {
+            Method getInstance = targetClass.getMethod(TUNE_SMARTWHERE_ATTRIBUTE_METHOD_GET_INSTANCE, Context.class);
+            Object instanceOfAttributeClass = getInstance.invoke(targetClass,context);
+            Method setAttributeValue = targetClass.getMethod(TUNE_SMARTWHERE_ATTRIBUTE_METHOD_SET_ATTRIBUTE_VALUE, String.class, String.class);
+            Method removeAttributeValue = targetClass.getMethod(TUNE_SMARTWHERE_ATTRIBUTE_METHOD_REMOVE_ATTRIBUTE_VALUE, String.class);
+            String name = analyticsVariable.getName();
+            String value = analyticsVariable.getValue();
+            if (name != null && name.length() > 0){
+                if ( value != null){
+                    String finalName = TUNE_SMARTWHERE_ANALYTICS_VARIABLE_ATTRIBUTE_PREFIX + name;
+                    setAttributeValue.invoke(instanceOfAttributeClass, finalName, value);
+                } else {
+                    String finalName = TUNE_SMARTWHERE_ANALYTICS_VARIABLE_ATTRIBUTE_PREFIX + name;
+                    removeAttributeValue.invoke(instanceOfAttributeClass, finalName);
+
+                }
+            }
+        } catch (Exception e) {
+            TuneUtils.log("TuneSmartWhere.setAttributeValueFromAnalyticsVariable: " + e.getLocalizedMessage());
+        }
+    }
+
+    /**
+     * Add user attributes that are used for conditions and notification replacements from TuneEvent tags.
+     * @param context Application Context
+     * @param event TuneEvent
+     */
+    public void setAttributeValuesFromEventTags(Context context, TuneEvent event) {
+        Class<?> targetClass = classForName(TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_ATTRIBUTE);
+        if (targetClass == null) return;
+
+        for (TuneAnalyticsVariable tag : event.getTags()) {
+            setAttributeValueFromAnalyticsVariable(context, tag);
+        }
+    }
+
+    /**
+     * Remove an attribute by name
+     * @param context Application Context
+     * @param variableName String
+     */
+    public void clearAttributeValue(Context context, String variableName) {
+        Class<?> targetClass = classForName(TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_ATTRIBUTE);
+        if (targetClass == null) return;
+
+        try {
+            Method getInstance = targetClass.getMethod(TUNE_SMARTWHERE_ATTRIBUTE_METHOD_GET_INSTANCE, Context.class);
+            Object instanceOfAttributeClass = getInstance.invoke(targetClass,context);
+            Method removeAttributeValue = targetClass.getMethod(TUNE_SMARTWHERE_ATTRIBUTE_METHOD_REMOVE_ATTRIBUTE_VALUE, String.class);
+
+            String finalName = TUNE_SMARTWHERE_ANALYTICS_VARIABLE_ATTRIBUTE_PREFIX + variableName;
+            removeAttributeValue.invoke(instanceOfAttributeClass, finalName);
+        } catch (Exception e) {
+            TuneUtils.log("TuneSmartWhere.clearAttributeValue: " + e.getLocalizedMessage());
+        }
+    }
+
+    /**
+     * Remove all attributes
+     * @param context Application Context
+     */
+    public void clearAllAttributeValues(Context context) {
+        Class<?> targetClass = classForName(TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_ATTRIBUTE);
+        if (targetClass == null) return;
+
+        try {
+            Method getInstance = targetClass.getMethod(TUNE_SMARTWHERE_ATTRIBUTE_METHOD_GET_INSTANCE, Context.class);
+            Object instanceOfAttributeClass = getInstance.invoke(targetClass,context);
+            Method removeAttributeValue = targetClass.getMethod(TUNE_SMARTWHERE_ATTRIBUTE_METHOD_REMOVE_ATTRIBUTE_VALUE, String.class);
+            Method getAttributeMap = targetClass.getMethod(TUNE_SMARTWHERE_ATTRIBUTE_METHOD_GET_ATTRIBUTE_MAP);
+            Object attributes = getAttributeMap.invoke(instanceOfAttributeClass);
+
+            ArrayList<String> keysToRemove = new ArrayList<>();
+            //noinspection unchecked
+            for (String name : ((HashMap<String, String>) attributes).keySet()) {
+                if (name.startsWith(TUNE_SMARTWHERE_ANALYTICS_VARIABLE_ATTRIBUTE_PREFIX)) {
+                    keysToRemove.add(name);
+                }
+            }
+            for (String name : keysToRemove) {
+                removeAttributeValue.invoke(instanceOfAttributeClass, name);
+            }
+        } catch (Exception e) {
+            TuneUtils.log("TuneSmartWhere.clearAllAttributeValues: " + e.getLocalizedMessage());
+        }
+    }
+
     static synchronized void setInstance(TuneSmartWhere tuneProximity) {
         instance = tuneProximity;
     }
 
     // Required for SmartWhere Unit Tests
+    @SuppressWarnings("WeakerAccess")
     protected boolean isSmartWhereAvailableInternal() {
         return classForName(TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_PROXIMITYCONTROL) != null;
     }

--- a/sdk-android/TuneMarketingConsoleSDK/src/main/java/com/tune/smartwhere/TuneSmartWhere.java
+++ b/sdk-android/TuneMarketingConsoleSDK/src/main/java/com/tune/smartwhere/TuneSmartWhere.java
@@ -26,7 +26,7 @@ import static com.tune.TuneEvent.NAME_SESSION;
 public class TuneSmartWhere {
     protected static volatile TuneSmartWhere instance = null;
 
-    static final String TUNE_SMARTWHERE_ANALYTICS_VARIABLE_ATTRIBUTE_PREFIX = "TUNE_ANALYTICS_VARIABLE_";
+    static final String TUNE_SMARTWHERE_ANALYTICS_VARIABLE_ATTRIBUTE_PREFIX = "T_A_V_";
 
     static final String TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_PROXIMITYCONTROL = "com.proximity.library.ProximityControl";
     static final String TUNE_SMARTWHERE_COM_PROXIMITY_LIBRARY_ATTRIBUTE = "com.proximity.library.Attribute";


### PR DESCRIPTION
I have some changes that we'd like to propose for the Tune SDK.
The main thing that it does is pass attributes through to smartwhere, with permission of course, via either added tags to a measured event or registered custom user profile variable. The values don't get sent to our servers but can be used for notification substitutions and conditions for determining whether an event should be fired.

In addition, it adds two tracking variables. The TUNE Version string and the TUNE Mat Id. These values will be passed to our servers with tracking and then passed along to TUNE for the IAM visit sending.

Thanks,
Gordon